### PR TITLE
Feat#4. 스키마 & 엔티티 정의

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @HyoTaek-Jang @delphox60

--- a/sql/20250117.SQL
+++ b/sql/20250117.SQL
@@ -1,0 +1,66 @@
+create table tarot_questions
+(
+    id              bigint auto_increment
+        primary key,
+    created_at      datetime(6)  null,
+    updated_at      datetime(6)  null,
+    question        varchar(255) not null,
+    reference_count bigint       not null comment '해당 질문을 사용한 횟수'
+)
+    comment '유저들이 작성한 타로질문';
+
+create table users
+(
+    id            bigint auto_increment
+        primary key,
+    created_at    datetime(6)  null,
+    updated_at    datetime(6)  null,
+    temp_user_key varchar(255) null comment '인증 도입 전 임시 사용자 키'
+);
+
+create table tarot_chat_rooms
+(
+    id         bigint auto_increment
+        primary key,
+    created_at datetime(6) null,
+    updated_at datetime(6) null,
+    user_id    bigint      not null,
+    constraint FKfetrndhgss9skr5uts2bfi318
+        foreign key (user_id) references users (id)
+            on delete cascade
+);
+
+create table tarot_chat_messages
+(
+    id                          bigint auto_increment
+        primary key,
+    created_at                  datetime(6)  null,
+    updated_at                  datetime(6)  null,
+    message                     varchar(255) not null,
+    message_type                varchar(50)  not null,
+    reference_tarot_question_id bigint       null comment '추천 질문 ID, MessageType == RECOMMEND_TAROT_QUESTION 일 경우 존재',
+    sender_type                 varchar(50)  not null,
+    tarot_name                  varchar(255) null comment '유저가 선택한 타로카드 이름, MessageType == TAROT_RESULT 일 경우 사용',
+    chat_room_id                bigint       not null,
+    sender_id                   bigint       null comment '메시지를 보낸 사용자, SYSTEM 메세지의 경우 null',
+    tarot                       varchar(50)  null comment '유저가 선택한 타로카드(Enum으로 관리), MessageType == TAROT_RESULT 일 경우 사용',
+    constraint FKbfpg6llb60ha84bb6uruacl97
+        foreign key (sender_id) references users (id),
+    constraint FKoku8whksvwouj9pshqbp0edbd
+        foreign key (chat_room_id) references tarot_chat_rooms (id)
+);
+
+create table tarot_results
+(
+    question_message_id bigint not null
+        primary key,
+    result_message_id   bigint not null comment '질문에 대한 결과 메시지, 선택된 타로카드 이름을 가짐',
+    constraint UK7ptc89oar6g3r41f3aqkm8av9
+        unique (result_message_id),
+    constraint FK97rr9hrn7sc3nmaglxuh398s5
+        foreign key (question_message_id) references tarot_chat_messages (id),
+    constraint FKqf43s1p31l164p7r0mdshv837
+        foreign key (result_message_id) references tarot_chat_messages (id)
+)
+    comment '질문 & 결과의 인과관계 연결을 위한 테이블';
+

--- a/src/main/kotlin/com/ddd/dddapi/common/annotation/RequestUser.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/annotation/RequestUser.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-@MustBeDocumented
 @Schema(hidden = true)
 annotation class RequestUser(
     @Schema(hidden = true)

--- a/src/main/kotlin/com/ddd/dddapi/domain/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/common/entity/BaseEntity.kt
@@ -1,0 +1,21 @@
+package com.ddd.dddapi.domain.common.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity (
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    var updatedAt: LocalDateTime? = null
+)

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/MessageSender.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/MessageSender.kt
@@ -1,0 +1,6 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+enum class MessageSender {
+    USER,
+    SYSTEM
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/MessageType.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/MessageType.kt
@@ -1,0 +1,11 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+enum class MessageType {
+    NORMAL,
+    TAROT_QUESTION,
+    RECOMMEND_TAROT_QUESTION,
+    FOLLOW_QUESTION,
+    INVALID_QUESTION,
+    NORMAL_RESULT,
+    TAROT_RESULT,
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotChatMessageEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotChatMessageEntity.kt
@@ -20,24 +20,25 @@ class TarotChatMessageEntity(
     val chatRoom: TarotChatRoomEntity,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "message_type", nullable = false)
+    @Column(name = "message_type", nullable = false, columnDefinition = "VARCHAR(50)")
     val messageType: MessageType,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "sender_type", nullable = false)
+    @Column(name = "sender_type", nullable = false, columnDefinition = "VARCHAR(50)")
     val senderType: MessageSender,
 
     @Column(name = "message", nullable = false)
     val message: String,
 
-    @Comment("메시지를 보낸 사용자, SYSTEM 메세지의 경우 null")
+    @Comment("메시지를 보낸 사용자, MessageSender == SYSTEM 일 경우 null")
     @JoinColumn(name = "sender_id", nullable = true)
     @ManyToOne(fetch = FetchType.LAZY, optional = true)
     val sender: UserEntity? = null,
 
-    @Comment("유저가 선택한 타로카드 이름, MessageType == TAROT_RESULT 일 경우 사용")
-    @Column(name = "tarot_name", nullable = true)
-    val tarotName: String? = null,
+    @Comment("유저가 선택한 타로카드(Enum으로 관리), MessageType == TAROT_RESULT 일 경우 사용")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tarot", nullable = true, columnDefinition = "VARCHAR(50)")
+    val tarot: TarotInfo? = null,
 
     @Comment("추천 질문 ID, MessageType == RECOMMEND_TAROT_QUESTION 일 경우 존재")
     @Column(name = "reference_tarot_question_id", nullable = true)

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotChatMessageEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotChatMessageEntity.kt
@@ -1,0 +1,47 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+import com.ddd.dddapi.domain.common.entity.BaseEntity
+import com.ddd.dddapi.domain.user.entity.UserEntity
+import jakarta.persistence.*
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.Comment
+
+@Entity
+@Table(name = "tarot_chat_messages")
+class TarotChatMessageEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0,
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    val chatRoom: TarotChatRoomEntity,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", nullable = false)
+    val messageType: MessageType,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_type", nullable = false)
+    val senderType: MessageSender,
+
+    @Column(name = "message", nullable = false)
+    val message: String,
+
+    @Comment("메시지를 보낸 사용자, SYSTEM 메세지의 경우 null")
+    @JoinColumn(name = "sender_id", nullable = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    val sender: UserEntity? = null,
+
+    @Comment("유저가 선택한 타로카드 이름, MessageType == TAROT_RESULT 일 경우 사용")
+    @Column(name = "tarot_name", nullable = true)
+    val tarotName: String? = null,
+
+    @Comment("추천 질문 ID, MessageType == RECOMMEND_TAROT_QUESTION 일 경우 존재")
+    @Column(name = "reference_tarot_question_id", nullable = true)
+    val referenceTarotQuestionId: Long? = null,
+): BaseEntity()
+
+

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotChatRoomEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotChatRoomEntity.kt
@@ -1,0 +1,23 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+import com.ddd.dddapi.domain.common.entity.BaseEntity
+import com.ddd.dddapi.domain.user.entity.UserEntity
+import jakarta.persistence.*
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+
+@Entity
+@Table(name = "tarot_chat_rooms")
+class TarotChatRoomEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0,
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: UserEntity,
+): BaseEntity()

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotInfo.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotInfo.kt
@@ -1,0 +1,7 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+enum class TarotInfo {
+    TAROT1,
+    TAROT2,
+    TAROT3
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotQuestionEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotQuestionEntity.kt
@@ -1,0 +1,22 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+import com.ddd.dddapi.domain.common.entity.BaseEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.Comment
+
+@Comment("유저들이 작성한 타로질문")
+@Entity
+@Table(name = "tarot_questions")
+class TarotQuestionEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0,
+
+    @Column(name = "question", nullable = false)
+    val question: String,
+
+    @Comment("해당 질문을 사용한 횟수")
+    @Column(name = "reference_count", nullable = false)
+    val referenceCount: Long = 1,
+): BaseEntity()

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotResultEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotResultEntity.kt
@@ -1,0 +1,20 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.Comment
+
+
+@Comment("질문 & 결과의 인과관계 연결을 위한 테이블")
+@Entity
+@Table(name = "tarot_results")
+class TarotResultEntity(
+    @Id
+    @OneToOne
+    @JoinColumn(name = "question_message_id", nullable = false)
+    val questionMessage: TarotChatMessageEntity,
+
+    @Comment("질문에 대한 결과 메시지, 선택된 타로카드 이름을 가짐")
+    @OneToOne
+    @JoinColumn(name = "result_message_id", nullable = false)
+    val resultMessage: TarotChatMessageEntity
+)

--- a/src/main/kotlin/com/ddd/dddapi/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/user/entity/UserEntity.kt
@@ -1,0 +1,21 @@
+package com.ddd.dddapi.domain.user.entity
+
+import com.ddd.dddapi.domain.common.entity.BaseEntity
+import jakarta.persistence.*
+import jakarta.validation.constraints.Size
+import org.hibernate.annotations.Comment
+
+
+@Entity
+@Table(name = "users")
+class UserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0,
+
+    @Comment("인증 도입 전 임시 사용자 키")
+    @Size(max = 255)
+    @Column(name = "temp_user_key")
+    var tempUserKey: String? = null,
+): BaseEntity()

--- a/src/main/kotlin/com/ddd/dddapi/external/notification/client/DiscordClient.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/notification/client/DiscordClient.kt
@@ -1,6 +1,5 @@
 package com.ddd.dddapi.external.notification.client
 
-import com.ddd.dddapi.external.dto.*
 import com.ddd.dddapi.external.notification.dto.*
 import com.ddd.dddapi.external.notification.properties.BizNotificationProperties
 import org.springframework.http.HttpHeaders

--- a/src/main/kotlin/com/ddd/dddapi/global/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/ddd/dddapi/global/handler/GlobalExceptionHandler.kt
@@ -1,4 +1,4 @@
-package com.ddd.dddapi.global.controller
+package com.ddd.dddapi.global.handler
 
 import com.ddd.dddapi.common.dto.DefaultResponseDto
 import com.ddd.dddapi.common.exception.BizException

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     password: rlafhrdnjs1
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,7 +6,7 @@ spring:
     password: # 필요
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:


### PR DESCRIPTION
## Issue
- close #4 

## Summary
- Entity 및 Schema 추가

## Description
회의 내용과 달라진 점이 하나 있습니다.
타로 선택시 타로질문 ChatMessage에 선택한 타로 정보를 담기로 했는데, 그것보다는 타로결과 ChatMessage에 타로 정보를 담는게 덜 번거롭다 생각하여 수정했습니다.
전체 스키마는 사진 첨부합니다.

![tarotyang](https://github.com/user-attachments/assets/cd98749f-b818-43d9-9433-254590f5b962)


