### PR TITLE
Feat#19. 카카오, 애플 OIDC 통신 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,11 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
 
+	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+	implementation("io.jsonwebtoken:jjwt:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/com/ddd/dddapi/common/util/JwtUtil.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/util/JwtUtil.kt
@@ -1,0 +1,35 @@
+package com.ddd.dddapi.common.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import org.springframework.stereotype.Component
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.*
+
+@Component
+class JwtUtil(
+    val objectMapper: ObjectMapper
+) {
+    fun convertToPublicKey(n: String, e: String): PublicKey {
+        val modulus = BigInteger(1, Base64.getUrlDecoder().decode(n))
+        val exponent = BigInteger(1, Base64.getUrlDecoder().decode(e))
+        val spec = RSAPublicKeySpec(modulus, exponent)
+        return KeyFactory.getInstance("RSA").generatePublic(spec)
+    }
+
+    fun claims(key: PublicKey, token: String): Claims = Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .body
+
+    fun decodeJwtHeader(token: String): Map<String, Any> {
+        val parts = token.split(".")
+        val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
+        return objectMapper.readValue(headerJson, Map::class.java) as Map<String, Any>
+    }
+}

--- a/src/main/kotlin/com/ddd/dddapi/external/social/client/AppleClient.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/client/AppleClient.kt
@@ -1,0 +1,52 @@
+package com.ddd.dddapi.external.social.client
+
+import com.ddd.dddapi.common.util.JwtUtil
+import com.ddd.dddapi.external.social.dto.SocialType
+import com.ddd.dddapi.external.social.dto.SocialUserInfo
+import com.ddd.dddapi.external.social.properties.AppleProperties
+import io.jsonwebtoken.Claims
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.security.PublicKey
+
+@Component
+class AppleClient(
+    val properties: AppleProperties,
+    val jwtUtil: JwtUtil
+): OidcStrategy {
+    private val restClient = RestClient.builder()
+        .baseUrl(properties.domain)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build()
+
+    override fun authenticate(token: String): SocialUserInfo {
+        val publicKey = fetchPublicKey(token)
+        val claims = getClaims(publicKey, token)
+        return createSocialUserInfo(claims)
+    }
+
+    private fun fetchPublicKey(idToken: String): PublicKey {
+        val header = jwtUtil.decodeJwtHeader(idToken)
+        val jwks = restClient.get()
+            .uri(properties.publicKeyPath)
+            .retrieve()
+            .toEntity(Map::class.java) as Map<String, Any>
+
+        val keys = jwks["keys"] as List<Map<String, Any>>
+        val keyData = keys.find { it["kid"] == header["kid"] } ?: throw IllegalArgumentException("No matching key found")
+        val n = keyData["n"] as String
+        val e = keyData["e"] as String
+
+        return jwtUtil.convertToPublicKey(n, e)
+    }
+
+    private fun getClaims(publicKey: PublicKey, idToken: String): Claims = jwtUtil.claims(publicKey, idToken)
+
+    private fun createSocialUserInfo(claims: Claims): SocialUserInfo =
+        SocialUserInfo(
+            socialType = SocialType.APPLE,
+            socialId = claims.subject as String,
+        )
+}

--- a/src/main/kotlin/com/ddd/dddapi/external/social/client/KakaoClient.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/client/KakaoClient.kt
@@ -1,0 +1,62 @@
+package com.ddd.dddapi.external.social.client
+
+import com.ddd.dddapi.common.util.JwtUtil
+import com.ddd.dddapi.external.social.dto.SocialType
+import com.ddd.dddapi.external.social.dto.SocialUserInfo
+import com.ddd.dddapi.external.social.properties.KakaoAuthProperties
+import io.jsonwebtoken.Claims
+import org.springframework.stereotype.Component
+import java.security.PublicKey
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.client.RestClient
+
+
+@Component
+class KakaoClient(
+    private val properties: KakaoAuthProperties,
+    private val jwtUtil: JwtUtil
+): OidcStrategy  {
+    private val restClient = RestClient.builder()
+        .baseUrl(properties.domain)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build()
+
+    override fun authenticate(token: String): SocialUserInfo {
+        val idToken = preAuthenticate(token)
+        val publicKey = fetchPublicKey()
+        val claims = getClaims(publicKey, idToken)
+        return createSocialUserInfo(claims)
+    }
+
+    private fun preAuthenticate(authorizationCode: String): String {
+        val tokenResponse = restClient.get()
+            .uri("${properties.receiveTokenPath}?grant_type=authorization_code&client_id=${properties.clientId}&redirect_uri=${properties.redirectUri}&code=${authorizationCode}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .retrieve()
+            .body(Map::class.java) as Map<String, Any>
+
+        return tokenResponse["id_token"] as String
+    }
+
+    private fun fetchPublicKey(): PublicKey {
+        val jwks = restClient.get()
+            .uri(properties.publicKeyPath)
+            .retrieve()
+            .toEntity(Map::class.java) as Map<String, Any>
+        val keys = jwks["keys"] as List<Map<String, Any>>
+        val keyData = keys[0]
+        val n = keyData["n"] as String
+        val e = keyData["e"] as String
+
+        return jwtUtil.convertToPublicKey(n, e)
+    }
+
+    private fun getClaims(publicKey: PublicKey, idToken: String): Claims = jwtUtil.claims(publicKey, idToken)
+
+    private fun createSocialUserInfo(claims: Claims): SocialUserInfo =
+        SocialUserInfo(
+            socialType = SocialType.KAKAO,
+            socialId = claims.subject as String,
+        )
+}

--- a/src/main/kotlin/com/ddd/dddapi/external/social/client/OidcStrategy.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/client/OidcStrategy.kt
@@ -1,0 +1,7 @@
+package com.ddd.dddapi.external.social.client
+
+import com.ddd.dddapi.external.social.dto.SocialUserInfo
+
+interface OidcStrategy {
+    fun authenticate(token: String): SocialUserInfo
+}

--- a/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialType.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialType.kt
@@ -1,0 +1,6 @@
+package com.ddd.dddapi.external.social.dto
+
+enum class SocialType {
+    KAKAO,
+    APPLE
+}

--- a/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialUserInfo.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialUserInfo.kt
@@ -1,0 +1,9 @@
+package com.ddd.dddapi.external.social.dto
+
+data class SocialUserInfo(
+    val socialType: SocialType,
+    val socialId: String,
+    val email: String? = null,
+    val name: String? = null,
+    val profileImage: String? = null,
+)

--- a/src/main/kotlin/com/ddd/dddapi/external/social/properties/AppleProperties.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/properties/AppleProperties.kt
@@ -1,0 +1,9 @@
+package com.ddd.dddapi.external.social.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external.apple")
+data class AppleProperties(
+    val domain: String,
+    val publicKeyPath: String,
+)

--- a/src/main/kotlin/com/ddd/dddapi/external/social/properties/KakaoAuthProperties.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/properties/KakaoAuthProperties.kt
@@ -1,0 +1,12 @@
+package com.ddd.dddapi.external.social.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external.kakao-auth")
+data class KakaoAuthProperties(
+    val domain: String,
+    val publicKeyPath: String,
+    val receiveTokenPath: String,
+    val redirectUri: String,
+    val clientId: String,
+)


### PR DESCRIPTION

## Issue
- close #19 

## Summary
- 카카오, 애플 로그인 OIDC 통신 로직 구현

## Description
- 소셜로그인 수행 방식을 통일시키기 위해 카카오, 애플 모두 OIDC를 사용했습니다.
- Open Public Key 파싱할때 데이터 클래스는 사용하지 않고 Map으로 처리했습니다. 1회성이라!