### PR TITLE
Feat#20. 소셜 로그인 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
 	implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
 
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
-	implementation("io.jsonwebtoken:jjwt:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 

--- a/script/sql/20250210.SQL
+++ b/script/sql/20250210.SQL
@@ -1,0 +1,12 @@
+-- 유저 테이블에 로그인 타입과 소셜 로그인 시 해당 소셜 내 유저 식별자를 추가합니다.
+-- 1. login_type 컬럼 추가
+ALTER TABLE users
+    ADD COLUMN login_type VARCHAR(50) DEFAULT 'GUEST' COMMENT '유저 로그인 정보';
+
+-- 2. social_id 컬럼 추가
+ALTER TABLE users
+    ADD COLUMN social_id VARCHAR(255) COMMENT '소셜 로그인 시 해당 소셜 내 유저 식별자';
+
+-- 3. temp_user_key user_key로 변경
+ALTER TABLE users
+    CHANGE COLUMN temp_user_key user_key VARCHAR(36) NOT NULL UNIQUE COMMENT '사용자 고유 식별자 (UUID)';

--- a/src/main/kotlin/com/ddd/dddapi/common/dto/JwtUserInfo.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/dto/JwtUserInfo.kt
@@ -1,0 +1,8 @@
+package com.ddd.dddapi.common.dto
+
+import com.ddd.dddapi.common.enums.ServiceRole
+
+data class JwtUserInfo(
+    val userKey: String,
+    val role: ServiceRole = ServiceRole.USER,
+)

--- a/src/main/kotlin/com/ddd/dddapi/common/dto/RequestUserInfo.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/dto/RequestUserInfo.kt
@@ -1,9 +1,12 @@
 package com.ddd.dddapi.common.dto
 
+import com.ddd.dddapi.common.enums.ServiceRole
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(hidden = true)
 data class RequestUserInfo(
     @Schema(hidden = true)
-    val userKey: String
+    val userKey: String,
+    @Schema(hidden = true)
+    val role: ServiceRole = ServiceRole.GUEST,
 )

--- a/src/main/kotlin/com/ddd/dddapi/common/enums/LoginType.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/enums/LoginType.kt
@@ -1,0 +1,7 @@
+package com.ddd.dddapi.common.enums
+
+enum class LoginType {
+    KAKAO,
+    APPLE,
+    GUEST
+}

--- a/src/main/kotlin/com/ddd/dddapi/common/enums/ServiceRole.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/enums/ServiceRole.kt
@@ -1,0 +1,7 @@
+package com.ddd.dddapi.common.enums
+
+enum class ServiceRole {
+    ADMIN,
+    USER,
+    GUEST
+}

--- a/src/main/kotlin/com/ddd/dddapi/common/properties/JwtProperties.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/properties/JwtProperties.kt
@@ -1,0 +1,11 @@
+package com.ddd.dddapi.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    val secretKey: String,
+    val accessExpirationHours: Long,
+    val refreshExpirationHours: Long,
+    val issuer: String
+)

--- a/src/main/kotlin/com/ddd/dddapi/common/util/JwtUtil.kt
+++ b/src/main/kotlin/com/ddd/dddapi/common/util/JwtUtil.kt
@@ -1,18 +1,31 @@
 package com.ddd.dddapi.common.util
 
+import com.ddd.dddapi.common.dto.JwtUserInfo
+import com.ddd.dddapi.common.enums.ServiceRole
+import com.ddd.dddapi.common.exception.UnauthorizedBizException
+import com.ddd.dddapi.common.properties.JwtProperties
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
 import org.springframework.stereotype.Component
 import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.PublicKey
 import java.security.spec.RSAPublicKeySpec
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.*
+import javax.crypto.spec.SecretKeySpec
+
+private const val USER_TOKEN_SUBJECT = "token"
+private const val JWT_CLAIM_USER_ID = "userId"
+private const val JWT_CLAIM_ROLE = "role"
 
 @Component
 class JwtUtil(
-    val objectMapper: ObjectMapper
+    val objectMapper: ObjectMapper,
+    val jwtProperties: JwtProperties
 ) {
     fun convertToPublicKey(n: String, e: String): PublicKey {
         val modulus = BigInteger(1, Base64.getUrlDecoder().decode(n))
@@ -31,5 +44,37 @@ class JwtUtil(
         val parts = token.split(".")
         val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
         return objectMapper.readValue(headerJson, Map::class.java) as Map<String, Any>
+    }
+
+    fun generateServiceToken(jwtUserInfo: JwtUserInfo): String {
+        return Jwts.builder()
+            .claim(JWT_CLAIM_USER_ID, jwtUserInfo.userKey)
+            .claim(JWT_CLAIM_ROLE, jwtUserInfo.role.name)
+            .setSubject(USER_TOKEN_SUBJECT)
+            .setIssuer(jwtProperties.issuer)
+            .setExpiration(
+                Date.from(
+                    Instant.now().plus(jwtProperties.accessExpirationHours, ChronoUnit.HOURS)
+                )
+            ) // 100년
+            .signWith(SecretKeySpec(jwtProperties.secretKey.toByteArray(), SignatureAlgorithm.HS256.jcaName))
+            .compact()
+    }
+
+    fun validateServiceToken(token: String): JwtUserInfo = try {
+        Jwts.parserBuilder()
+            .setSigningKey(jwtProperties.secretKey.toByteArray())
+            .build()
+            .parseClaimsJws(token)
+            .body
+            .let {
+                JwtUserInfo(
+                    userKey = it.get(key = JWT_CLAIM_USER_ID) as String,
+                    role = enumValueOf(
+                        it.get(key = JWT_CLAIM_ROLE) as? String ?: ServiceRole.GUEST.name),
+                )
+            }
+    } catch (e: Exception) {
+        throw UnauthorizedBizException("잘못된 서비스 토큰입니다.")
     }
 }

--- a/src/main/kotlin/com/ddd/dddapi/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/auth/controller/AuthController.kt
@@ -1,0 +1,40 @@
+package com.ddd.dddapi.domain.auth.controller
+
+import com.ddd.dddapi.common.annotation.UserKeyIgnored
+import com.ddd.dddapi.domain.auth.dto.AppleSignInRequestDto
+import com.ddd.dddapi.domain.auth.dto.KakaoSignInRequestDto
+import com.ddd.dddapi.domain.auth.dto.TokenResponseDto
+import com.ddd.dddapi.domain.auth.service.AuthService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/v1/auth")
+@Tag(name = "00. Auth API")
+class AuthController(
+    private val authService: AuthService
+) {
+    @Operation(summary = "카카오 로그인", description = "카카오 로그인을 합니다")
+    @UserKeyIgnored
+    @PostMapping("/kakao")
+    fun kakaoSignIn(
+        @Valid @RequestBody request: KakaoSignInRequestDto
+    ): TokenResponseDto {
+        return authService.kakaoSignIn(request.authorizationCode)
+    }
+
+    @Operation(summary = "애플 로그인", description = "애플 로그인을 합니다")
+    @UserKeyIgnored
+    @PostMapping("/apple")
+    fun appleSignIn(
+        @Valid @RequestBody request: AppleSignInRequestDto
+    ): TokenResponseDto {
+        return authService.appleSignIn(request.idToken)
+    }
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/auth/dto/AppleSignInRequestDto.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/auth/dto/AppleSignInRequestDto.kt
@@ -1,0 +1,8 @@
+package com.ddd.dddapi.domain.auth.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AppleSignInRequestDto(
+    @field:Schema(description = "애플 로그인 시 발급받은 id token", example = "jwt 형식")
+    val idToken: String,
+)

--- a/src/main/kotlin/com/ddd/dddapi/domain/auth/dto/KakaoSignInRequestDto.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/auth/dto/KakaoSignInRequestDto.kt
@@ -1,0 +1,8 @@
+package com.ddd.dddapi.domain.auth.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class KakaoSignInRequestDto(
+    @field:Schema(description = "카카오 로그인 시 발급받은 authorization code", example = "asdf31dsf")
+    val authorizationCode: String
+)

--- a/src/main/kotlin/com/ddd/dddapi/domain/auth/dto/TokenResponseDto.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/auth/dto/TokenResponseDto.kt
@@ -1,0 +1,8 @@
+package com.ddd.dddapi.domain.auth.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class TokenResponseDto(
+    @field:Schema(description = "타로냥 접근용 jwt Token", example = "jwt 형식")
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/ddd/dddapi/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/auth/service/AuthService.kt
@@ -1,0 +1,8 @@
+package com.ddd.dddapi.domain.auth.service
+
+import com.ddd.dddapi.domain.auth.dto.TokenResponseDto
+
+interface AuthService {
+    fun kakaoSignIn(authorizationCode: String): TokenResponseDto
+    fun appleSignIn(idToken: String): TokenResponseDto
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/auth/service/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/auth/service/AuthServiceImpl.kt
@@ -1,0 +1,47 @@
+package com.ddd.dddapi.domain.auth.service
+
+import com.ddd.dddapi.common.dto.JwtUserInfo
+import com.ddd.dddapi.common.util.JwtUtil
+import com.ddd.dddapi.domain.auth.dto.TokenResponseDto
+import com.ddd.dddapi.domain.user.entity.UserEntity
+import com.ddd.dddapi.domain.user.repository.UserRepository
+import com.ddd.dddapi.domain.user.service.helper.UserHelperService
+import com.ddd.dddapi.external.social.client.OidcStrategy
+import com.ddd.dddapi.external.social.dto.SocialUserInfo
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthServiceImpl(
+    private val kakaoClient: OidcStrategy,
+    private val appleClient: OidcStrategy,
+    private val jwtUtil: JwtUtil,
+    private val userHelperService: UserHelperService,
+    private val userRepository: UserRepository,
+): AuthService {
+    @Transactional
+    override fun kakaoSignIn(authorizationCode: String): TokenResponseDto {
+        val socialUserInfo = kakaoClient.authenticate(authorizationCode)
+        val user = getOrCreateUser(socialUserInfo)
+        val accessToken = jwtUtil.generateServiceToken(JwtUserInfo(userKey = user.userKey))
+
+        return TokenResponseDto(accessToken)
+    }
+
+    @Transactional
+    override fun appleSignIn(idToken: String): TokenResponseDto {
+        val socialUserInfo = appleClient.authenticate(idToken)
+        val user = getOrCreateUser(socialUserInfo)
+        val accessToken = jwtUtil.generateServiceToken(JwtUserInfo(userKey = user.userKey))
+
+        return TokenResponseDto(accessToken)
+    }
+
+    private fun getOrCreateUser(socialUserInfo: SocialUserInfo): UserEntity {
+        return userHelperService.getUserOrNull(socialUserInfo.socialType, socialUserInfo.socialId)
+            ?: userRepository.save(UserEntity(
+                socialId = socialUserInfo.socialId,
+                loginType = socialUserInfo.socialType,
+            ))
+    }
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/shared/controller/SharedController.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/shared/controller/SharedController.kt
@@ -1,11 +1,10 @@
-package com.ddd.dddapi.domain.common.controller
+package com.ddd.dddapi.domain.shared.controller
 
 import com.ddd.dddapi.common.annotation.RequestUser
 import com.ddd.dddapi.common.dto.DefaultResponse
 import com.ddd.dddapi.common.dto.RequestUserInfo
-import com.ddd.dddapi.domain.common.dto.ShareLoggingRequestDto
-import com.ddd.dddapi.domain.common.service.CommonServiceImpl
-import com.ddd.dddapi.domain.common.service.ShareLogService
+import com.ddd.dddapi.domain.shared.dto.ShareLoggingRequestDto
+import com.ddd.dddapi.domain.shared.service.ShareLogService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -15,9 +14,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/v1/common")
+@RequestMapping("/v1/shared")
 @Tag(name = "00. Common API")
-class CommonController(
+class SharedController(
     private val commonService: ShareLogService
 ) {
     @Operation(summary = "질문 공유하기 로깅", description = "공유하기 시 로깅용 API")

--- a/src/main/kotlin/com/ddd/dddapi/domain/shared/dto/ShareLoggingRequestDto.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/shared/dto/ShareLoggingRequestDto.kt
@@ -1,4 +1,4 @@
-package com.ddd.dddapi.domain.common.dto
+package com.ddd.dddapi.domain.shared.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/src/main/kotlin/com/ddd/dddapi/domain/shared/entity/ShareLogEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/shared/entity/ShareLogEntity.kt
@@ -1,5 +1,6 @@
-package com.ddd.dddapi.domain.common.entity
+package com.ddd.dddapi.domain.shared.entity
 
+import com.ddd.dddapi.domain.common.entity.BaseEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 

--- a/src/main/kotlin/com/ddd/dddapi/domain/shared/repository/ShareLogRepository.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/shared/repository/ShareLogRepository.kt
@@ -1,6 +1,6 @@
-package com.ddd.dddapi.domain.common.repository
+package com.ddd.dddapi.domain.shared.repository
 
-import com.ddd.dddapi.domain.common.entity.ShareLogEntity
+import com.ddd.dddapi.domain.shared.entity.ShareLogEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ShareLogRepository: JpaRepository<ShareLogEntity, Long> {

--- a/src/main/kotlin/com/ddd/dddapi/domain/shared/service/ShareLogService.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/shared/service/ShareLogService.kt
@@ -1,4 +1,4 @@
-package com.ddd.dddapi.domain.common.service
+package com.ddd.dddapi.domain.shared.service
 
 interface ShareLogService {
     fun saveShareLog(tarotResultId: Long)

--- a/src/main/kotlin/com/ddd/dddapi/domain/shared/service/SharedServiceImpl.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/shared/service/SharedServiceImpl.kt
@@ -1,12 +1,12 @@
-package com.ddd.dddapi.domain.common.service
+package com.ddd.dddapi.domain.shared.service
 
-import com.ddd.dddapi.domain.common.entity.ShareLogEntity
-import com.ddd.dddapi.domain.common.repository.ShareLogRepository
+import com.ddd.dddapi.domain.shared.entity.ShareLogEntity
+import com.ddd.dddapi.domain.shared.repository.ShareLogRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class CommonServiceImpl(
+class SharedServiceImpl(
     private val shareLogRepository: ShareLogRepository
 ): ShareLogService {
     @Transactional

--- a/src/main/kotlin/com/ddd/dddapi/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/user/entity/UserEntity.kt
@@ -1,9 +1,11 @@
 package com.ddd.dddapi.domain.user.entity
 
+import com.ddd.dddapi.common.enums.LoginType
 import com.ddd.dddapi.domain.common.entity.BaseEntity
 import jakarta.persistence.*
 import jakarta.validation.constraints.Size
 import org.hibernate.annotations.Comment
+import java.util.*
 
 
 @Entity
@@ -14,8 +16,16 @@ class UserEntity(
     @Column(name = "id", nullable = false)
     val id: Long = 0,
 
-    @Comment("인증 도입 전 임시 사용자 키")
-    @Size(max = 255)
-    @Column(name = "temp_user_key")
-    var tempUserKey: String? = null,
+    @Comment("사용자 고유 식별자 (UUID)")
+    @Column(name = "user_key", nullable = false, unique = true, updatable = false, columnDefinition = "VARCHAR(36)")
+    var userKey: String = UUID.randomUUID().toString(),
+
+    @Comment("유저 로그인 정보")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type", nullable = true, columnDefinition = "VARCHAR(50)")
+    var loginType: LoginType? = LoginType.GUEST,
+
+    @Comment("소셜 로그인 시 해당 소셜 내 유저 식별자")
+    @Column(name = "social_id", nullable = true, columnDefinition = "VARCHAR(255)")
+    val socialId: String? = null,
 ): BaseEntity()

--- a/src/main/kotlin/com/ddd/dddapi/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/user/repository/UserRepository.kt
@@ -1,8 +1,11 @@
 package com.ddd.dddapi.domain.user.repository
 
+import com.ddd.dddapi.common.enums.LoginType
 import com.ddd.dddapi.domain.user.entity.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository: JpaRepository<UserEntity, Long> {
-    fun findByTempUserKey(tempUserKey: String): UserEntity?
+    fun findByUserKey(userKey: String): UserEntity?
+
+    fun findByLoginTypeAndSocialId(loginType: LoginType, socialId: String): UserEntity?
 }

--- a/src/main/kotlin/com/ddd/dddapi/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/user/service/UserServiceImpl.kt
@@ -1,6 +1,5 @@
 package com.ddd.dddapi.domain.user.service
 
-import com.ddd.dddapi.common.exception.BadRequestBizException
 import com.ddd.dddapi.domain.user.entity.UserEntity
 import com.ddd.dddapi.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
@@ -12,7 +11,7 @@ class UserServiceImpl(
 ): UserService {
     @Transactional
     override fun getOrCreateUser(tempUserKey: String): UserEntity {
-        val user = userRepository.findByTempUserKey(tempUserKey)
-        return user ?: userRepository.save(UserEntity(tempUserKey = tempUserKey))
+        val user = userRepository.findByUserKey(tempUserKey)
+        return user ?: userRepository.save(UserEntity(userKey = tempUserKey))
     }
 }

--- a/src/main/kotlin/com/ddd/dddapi/domain/user/service/helper/UserHelperService.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/user/service/helper/UserHelperService.kt
@@ -1,9 +1,11 @@
 package com.ddd.dddapi.domain.user.service.helper
 
+import com.ddd.dddapi.common.enums.LoginType
 import com.ddd.dddapi.common.exception.BadRequestBizException
 import com.ddd.dddapi.domain.common.annotation.HelperService
 import com.ddd.dddapi.domain.user.entity.UserEntity
 import com.ddd.dddapi.domain.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 
 @HelperService
@@ -11,8 +13,24 @@ import org.springframework.transaction.annotation.Transactional
 class UserHelperService(
     private val userRepository: UserRepository
 ) {
+    fun getUserOrThrow(id: Long): UserEntity {
+        return userRepository.findByIdOrNull(id)
+            ?: throw BadRequestBizException("해당 유저가 존재하지 않습니다. [id: $id]")
+    }
+
     fun getUserOrThrow(tempUserKey: String): UserEntity {
-        return userRepository.findByTempUserKey(tempUserKey)
+        return userRepository.findByUserKey(tempUserKey)
             ?: throw BadRequestBizException("해당 유저가 존재하지 않습니다. [tempUserKey: $tempUserKey]")
+    }
+
+    fun getUserOrThrow(type: LoginType, key: String): UserEntity {
+        if (type == LoginType.GUEST) return getUserOrThrow(key)
+        return userRepository.findByLoginTypeAndSocialId(type, key)
+            ?: throw BadRequestBizException("해당 유저가 존재하지 않습니다. [type: $type socialId: $key]")
+    }
+
+    fun getUserOrNull(type: LoginType, key: String): UserEntity? {
+        if (type == LoginType.GUEST) return userRepository.findByUserKey(key)
+        return userRepository.findByLoginTypeAndSocialId(type, key)
     }
 }

--- a/src/main/kotlin/com/ddd/dddapi/external/social/client/AppleClient.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/client/AppleClient.kt
@@ -1,7 +1,7 @@
 package com.ddd.dddapi.external.social.client
 
+import com.ddd.dddapi.common.enums.LoginType
 import com.ddd.dddapi.common.util.JwtUtil
-import com.ddd.dddapi.external.social.dto.SocialType
 import com.ddd.dddapi.external.social.dto.SocialUserInfo
 import com.ddd.dddapi.external.social.properties.AppleProperties
 import io.jsonwebtoken.Claims
@@ -46,7 +46,7 @@ class AppleClient(
 
     private fun createSocialUserInfo(claims: Claims): SocialUserInfo =
         SocialUserInfo(
-            socialType = SocialType.APPLE,
+            socialType = LoginType.APPLE,
             socialId = claims.subject as String,
         )
 }

--- a/src/main/kotlin/com/ddd/dddapi/external/social/client/KakaoClient.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/client/KakaoClient.kt
@@ -1,7 +1,7 @@
 package com.ddd.dddapi.external.social.client
 
+import com.ddd.dddapi.common.enums.LoginType
 import com.ddd.dddapi.common.util.JwtUtil
-import com.ddd.dddapi.external.social.dto.SocialType
 import com.ddd.dddapi.external.social.dto.SocialUserInfo
 import com.ddd.dddapi.external.social.properties.KakaoAuthProperties
 import io.jsonwebtoken.Claims
@@ -56,7 +56,7 @@ class KakaoClient(
 
     private fun createSocialUserInfo(claims: Claims): SocialUserInfo =
         SocialUserInfo(
-            socialType = SocialType.KAKAO,
+            socialType = LoginType.KAKAO,
             socialId = claims.subject as String,
         )
 }

--- a/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialType.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialType.kt
@@ -1,6 +1,0 @@
-package com.ddd.dddapi.external.social.dto
-
-enum class SocialType {
-    KAKAO,
-    APPLE
-}

--- a/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialUserInfo.kt
+++ b/src/main/kotlin/com/ddd/dddapi/external/social/dto/SocialUserInfo.kt
@@ -1,7 +1,9 @@
 package com.ddd.dddapi.external.social.dto
 
+import com.ddd.dddapi.common.enums.LoginType
+
 data class SocialUserInfo(
-    val socialType: SocialType,
+    val socialType: LoginType,
     val socialId: String,
     val email: String? = null,
     val name: String? = null,

--- a/src/main/kotlin/com/ddd/dddapi/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/ddd/dddapi/global/config/WebMvcConfig.kt
@@ -1,5 +1,6 @@
 package com.ddd.dddapi.global.config
 
+import com.ddd.dddapi.common.util.JwtUtil
 import com.ddd.dddapi.external.notification.client.BizNotificationClient
 import com.ddd.dddapi.global.filter.ExceptionHandleFilter
 import com.ddd.dddapi.global.filter.TraceFilter
@@ -16,9 +17,11 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebMvcConfig: WebMvcConfigurer {
+class WebMvcConfig(
+    private val jwtUtil: JwtUtil
+): WebMvcConfigurer {
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(RequestUserArgumentResolver())
+        resolvers.add(RequestUserArgumentResolver(jwtUtil))
     }
 
     override fun addCorsMappings(registry: CorsRegistry) {


### PR DESCRIPTION

## Issue
- close #20 

## Summary
- 소셜 로그인 API 구현
- 기존 유저식별 방식과 호환되도록 설계 

## Description
- UserEntity에 socialId, socialType을 추가했고 tempUserKey로 사용중이던 컬럼을 userKey로 수정(uuid 담을 컬럼) 했습니다. 변경 쿼리는 SQL 파일 참고해주세요!
- 아직 인증/권한을 위한 Filter나 Interceptor에서 체크하지는 않습니다. 핸들러메서드에서 인증정보를 필요로 할때 ArgumentResolver에서 체크하는 방식이라 더 수정이 필요합니다. 3차 MVP의 윤곽이 잡힐때 인증/권한 관련해서 재정리 후 개발 예정입니다.
