### PR TITLE
Feat#33. 꼬리질문 API 재구현

### DIFF
--- a/script/sql/20250222.SQL
+++ b/script/sql/20250222.SQL
@@ -1,0 +1,20 @@
+-- question column type - TEXT 변경
+ALTER TABLE tarot_questions
+    MODIFY COLUMN question TEXT NOT NULL;
+
+-- entity 추가
+CREATE TABLE tarot_result_follow_questions (
+   id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT 'PK',
+
+   tarot_result_id BIGINT NOT NULL COMMENT '타로 결과 ID',
+
+   questions_string TEXT NULL COMMENT '추천 꼬리질문들. \n 로 구분',
+
+   created_at      datetime(6)  null,
+   updated_at      datetime(6)  null,
+
+   CONSTRAINT fk_tarot_result_follow_questions_tarot_result
+       FOREIGN KEY (tarot_result_id) REFERENCES tarotnyang.tarot_results(id)
+           ON DELETE CASCADE
+);
+    comment '타로결과에 대한 추천 꼬리질문';

--- a/script/sql/20250222.SQL
+++ b/script/sql/20250222.SQL
@@ -16,5 +16,5 @@ CREATE TABLE tarot_result_follow_questions (
    CONSTRAINT fk_tarot_result_follow_questions_tarot_result
        FOREIGN KEY (tarot_result_id) REFERENCES tarotnyang.tarot_results(id)
            ON DELETE CASCADE
-);
+)
     comment '타로결과에 대한 추천 꼬리질문';

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/controller/TarotController.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/controller/TarotController.kt
@@ -51,7 +51,7 @@ class TarotController(
     fun getFollowTarotQuestions(
         request: FollowTarotQuestionRequestDto
     ): FollowTarotQuestionListResponseDto {
-        return tarotService.getFollowTarotQuestions(request.chatRoomId)
+        return tarotService.getFollowTarotQuestions(request)
     }
 
     @Operation(summary = "타로 히스토리 리스트", description = "본인이 받은 타로 히스토리 리스트를 가져옵니다.")

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/dto/FollowTarotQuestionRequestDto.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/dto/FollowTarotQuestionRequestDto.kt
@@ -4,5 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 data class FollowTarotQuestionRequestDto(
     @field:Schema(description = "현재 참여중인 채팅방 ID", example = "9")
-    val chatRoomId: Long
+    val chatRoomId: Long,
+    @field:Schema(description = "타로 결과 ID", example = "1")
+    val tarotResultId: Long
 )

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotQuestionEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotQuestionEntity.kt
@@ -13,7 +13,8 @@ class TarotQuestionEntity(
     @Column(name = "id", nullable = false)
     val id: Long = 0,
 
-    @Column(name = "question", nullable = false)
+    @Lob
+    @Column(name = "question", nullable = false, columnDefinition = "TEXT")
     val question: String,
 
     @Comment("해당 질문을 사용한 횟수")

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotResultFollowQuestionEntity.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/entity/TarotResultFollowQuestionEntity.kt
@@ -1,0 +1,35 @@
+package com.ddd.dddapi.domain.tarot.entity
+
+import com.ddd.dddapi.domain.common.entity.BaseEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.Comment
+
+@Comment("타로결과에 대한 추천 꼬리질문")
+@Entity
+@Table(name = "tarot_result_follow_questions")
+class TarotResultFollowQuestionEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tarot_result_id", nullable = false)
+    val tarotResult: TarotResultEntity,
+
+    @Lob
+    @Column(name = "questions_string", nullable = true, columnDefinition = "TEXT")
+    val questionsString: String?,
+): BaseEntity() {
+    companion object {
+        fun create(tarotResult: TarotResultEntity, questions: List<String>): TarotResultFollowQuestionEntity {
+            return TarotResultFollowQuestionEntity(
+                tarotResult = tarotResult,
+                questionsString = questions.joinToString("\n"))
+        }
+    }
+
+    fun getQuestions(): List<String> {
+        return questionsString?.split("\n") ?: emptyList()
+    }
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/repository/TarotResultFollowQuestionRepository.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/repository/TarotResultFollowQuestionRepository.kt
@@ -1,0 +1,8 @@
+package com.ddd.dddapi.domain.tarot.repository
+
+import com.ddd.dddapi.domain.tarot.entity.TarotResultFollowQuestionEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TarotResultFollowQuestionRepository: JpaRepository<TarotResultFollowQuestionEntity, Long> {
+    fun findByTarotResultId(tarotResultId: Long): List<TarotResultFollowQuestionEntity>
+}

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/service/TarotService.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/service/TarotService.kt
@@ -1,14 +1,11 @@
 package com.ddd.dddapi.domain.tarot.service
 
 import com.ddd.dddapi.domain.chat.dto.ChatMessageResponseDto
-import com.ddd.dddapi.domain.tarot.dto.FollowTarotQuestionListResponseDto
-import com.ddd.dddapi.domain.tarot.dto.RecommendTarotQuestionListResponseDto
-import com.ddd.dddapi.domain.tarot.dto.TarotResultResponseDto
-import com.ddd.dddapi.domain.tarot.dto.TarotSelectRequestDto
+import com.ddd.dddapi.domain.tarot.dto.*
 
 interface TarotService {
     fun selectTarot(tempUserKey: String, request: TarotSelectRequestDto): ChatMessageResponseDto
     fun getTarotResult(userKey: String?, tarotResultId: Long): TarotResultResponseDto
     fun getRecommendTarotQuestions(): RecommendTarotQuestionListResponseDto
-    fun getFollowTarotQuestions(chatRoomId: Long): FollowTarotQuestionListResponseDto
+    fun getFollowTarotQuestions(request: FollowTarotQuestionRequestDto): FollowTarotQuestionListResponseDto
 }

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/service/TarotServiceImpl.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/service/TarotServiceImpl.kt
@@ -7,7 +7,9 @@ import com.ddd.dddapi.domain.chat.repository.TarotChatMessageRepository
 import com.ddd.dddapi.domain.chat.service.helper.ChatHelperService
 import com.ddd.dddapi.domain.tarot.dto.*
 import com.ddd.dddapi.domain.tarot.entity.TarotResultEntity
+import com.ddd.dddapi.domain.tarot.entity.TarotResultFollowQuestionEntity
 import com.ddd.dddapi.domain.tarot.repository.TarotQuestionRepository
+import com.ddd.dddapi.domain.tarot.repository.TarotResultFollowQuestionRepository
 import com.ddd.dddapi.domain.tarot.repository.TarotResultRepository
 import com.ddd.dddapi.domain.tarot.service.helper.TarotHelperService
 import com.ddd.dddapi.domain.user.service.helper.UserHelperService
@@ -29,7 +31,8 @@ class TarotServiceImpl(
     private val tarotHelperService: TarotHelperService,
     private val tarotQuestionRepository: TarotQuestionRepository,
     private val tarotResultRepository: TarotResultRepository,
-    private val tarotChatMessageRepository: TarotChatMessageRepository
+    private val tarotChatMessageRepository: TarotChatMessageRepository,
+    private val tarotResultFollowQuestionRepository: TarotResultFollowQuestionRepository,
 ): TarotService {
     @Transactional
     override fun selectTarot(tempUserKey: String, request: TarotSelectRequestDto): ChatMessageResponseDto {
@@ -76,14 +79,28 @@ class TarotServiceImpl(
     }
 
     @Transactional
-    override fun getFollowTarotQuestions(chatRoomId: Long): FollowTarotQuestionListResponseDto {
-        val chatRoom = chatHelperService.getChatRoomOrThrow(chatRoomId)
-        val tarotFollowQuestions = aiClient.tarotFollowQuestion(
-            AiTarotFollowQuestionRequestDto(chatRoom.id.toString())
-        )
+    override fun getFollowTarotQuestions(request: FollowTarotQuestionRequestDto): FollowTarotQuestionListResponseDto {
+        val chatRoom = chatHelperService.getChatRoomOrThrow(request.chatRoomId)
+
+        val tarotFollowQuestions = getFollowQuestions(request.chatRoomId, request.tarotResultId)
+
         return FollowTarotQuestionListResponseDto(
-            tarotFollowQuestions.followUpQuestion
+            tarotFollowQuestions
         )
+    }
+
+    private fun getFollowQuestions(chatRoomId: Long, tarotResultId: Long): List<String> {
+        val chatRoom = chatHelperService.getChatRoomOrThrow(chatRoomId)
+        val tarotResult = tarotHelperService.getTarotResultOrThrow(tarotResultId)
+
+        return tarotHelperService.getTarotResultFollowQuestionsOrNull(tarotResultId)
+                ?: aiClient.tarotFollowQuestion( AiTarotFollowQuestionRequestDto(chatRoom.id.toString()))
+                    .followUpQuestion
+                    .apply {
+                        tarotResultFollowQuestionRepository.save(
+                            TarotResultFollowQuestionEntity.create(tarotResult, this)
+                        )
+                    }
     }
 
     private fun createTarotResultEntity(

--- a/src/main/kotlin/com/ddd/dddapi/domain/tarot/service/helper/TarotHelperService.kt
+++ b/src/main/kotlin/com/ddd/dddapi/domain/tarot/service/helper/TarotHelperService.kt
@@ -5,6 +5,7 @@ import com.ddd.dddapi.domain.common.annotation.HelperService
 import com.ddd.dddapi.domain.tarot.entity.TarotResultEntity
 import com.ddd.dddapi.domain.tarot.repository.TarotHistoryRepository
 import com.ddd.dddapi.domain.tarot.repository.TarotQuestionRepository
+import com.ddd.dddapi.domain.tarot.repository.TarotResultFollowQuestionRepository
 import com.ddd.dddapi.domain.tarot.repository.TarotResultRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
@@ -13,9 +14,16 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class TarotHelperService(
     private val tarotResultRepository: TarotResultRepository,
+    private val tarotResultFollowQuestionRepository: TarotResultFollowQuestionRepository,
 ) {
     fun getTarotResultOrThrow(tarotResultId: Long): TarotResultEntity {
         return tarotResultRepository.findByIdOrNull(tarotResultId)
             ?: throw BadRequestBizException("타로 결과를 찾을 수 없습니다. id: $tarotResultId")
+    }
+
+    fun getTarotResultFollowQuestionsOrNull(tarotResultId: Long): List<String>? {
+        return tarotResultFollowQuestionRepository.findByTarotResultId(tarotResultId)
+            .firstOrNull()
+            ?.getQuestions()
     }
 }


### PR DESCRIPTION

## Issue
- close #33 

## Summary
- 꼬리질문 API 재구현 - 꼬리질문 한 번 생성 후 DB에 저장(정규화 무시)

## Description
- 추가) TarotQuestionEntity의 question 컬럼 TEXT 타입으로 변경